### PR TITLE
[#47] 사용자 검색 기능 구현

### DIFF
--- a/com.jv-cc.flowmesh.auth/build.gradle
+++ b/com.jv-cc.flowmesh.auth/build.gradle
@@ -28,6 +28,15 @@ ext {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-hateoas'
+
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.jetbrains:annotations:24.1.0'
+
 	// postgres
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.4'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/application/dto/UserInfoDto.java
+++ b/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/application/dto/UserInfoDto.java
@@ -1,5 +1,6 @@
 package com.jv_cc.flowmesh.auth.application.dto;
 
+import com.jv_cc.flowmesh.auth.domain.model.Auth;
 import com.jv_cc.flowmesh.auth.domain.model.UserRoleEnum;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,4 +16,13 @@ public class UserInfoDto {
     private String email;
     private String slackId;
     private UserRoleEnum role;
+
+    public UserInfoDto(Auth auth) {
+        this.id = auth.getId();
+        this.username = auth.getUsername();
+        this.nickname = auth.getNickname();
+        this.email = auth.getEmail();
+        this.slackId = auth.getSlackId();
+        this.role = auth.getRole();
+    }
 }

--- a/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/domain/repository/AuthRepository.java
+++ b/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/domain/repository/AuthRepository.java
@@ -1,6 +1,8 @@
 package com.jv_cc.flowmesh.auth.domain.repository;
 
 import com.jv_cc.flowmesh.auth.domain.model.Auth;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -21,4 +23,6 @@ public interface AuthRepository extends JpaRepository<Auth, Long> {
     Optional<Auth> findByIdAndIsDeletedFalse(Long id);
 
     Optional<Auth> findByRefreshTokenAndIsDeletedFalse(String refreshToken);
+
+    Page<Auth> findAllByUsernameAndIsDeletedFalse(String username, Pageable pageable);
 }

--- a/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/infrastructor/constants/PageOrderType.java
+++ b/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/infrastructor/constants/PageOrderType.java
@@ -1,0 +1,16 @@
+package com.jv_cc.flowmesh.auth.infrastructor.constants;
+
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public enum PageOrderType {
+    ASC(Sort.Direction.ASC),
+    DESC(Sort.Direction.DESC);
+
+    private final Sort.Direction direction;
+
+    PageOrderType(Sort.Direction direction) {
+        this.direction = direction;
+    }
+}

--- a/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/infrastructor/constants/PageSortType.java
+++ b/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/infrastructor/constants/PageSortType.java
@@ -1,0 +1,17 @@
+package com.jv_cc.flowmesh.auth.infrastructor.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum PageSortType {
+    USERNAME("username"),
+    NICKNAME("nickname"),
+    EMAIL("email"),
+    ROLE("role");
+
+    private final String label;
+
+    PageSortType(String label) {
+        this.label = label;
+    }
+}

--- a/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/presentation/controller/UserController.java
+++ b/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/presentation/controller/UserController.java
@@ -2,13 +2,19 @@ package com.jv_cc.flowmesh.auth.presentation.controller;
 
 import com.jv_cc.flowmesh.auth.application.dto.UserInfoDto;
 import com.jv_cc.flowmesh.auth.application.util.JwtUtil;
+import com.jv_cc.flowmesh.auth.domain.model.UserRoleEnum;
 import com.jv_cc.flowmesh.auth.domain.service.UserService;
-import com.jv_cc.flowmesh.auth.presentation.response.ResDTO;
+import com.jv_cc.flowmesh.auth.presentation.request.SearchReqDto;
 import com.jv_cc.flowmesh.auth.presentation.request.UserReqDto;
+import com.jv_cc.flowmesh.auth.presentation.response.ResDTO;
 import com.jv_cc.flowmesh.auth.presentation.response.UserResDto;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -48,11 +54,11 @@ public class UserController {
 
     @PutMapping("/{users_id}")
     public ResponseEntity<ResDTO<Map<String, String>>> updateUser(
-            @NotNull @RequestHeader(name = JwtUtil.JwtHeader.KEY_USER_ROLE) String tokenUserRole,
+            @NotNull @RequestHeader(name = JwtUtil.JwtHeader.KEY_USER_ROLE) UserRoleEnum tokenUserRole,
             @NotNull @RequestHeader(name = JwtUtil.JwtHeader.KEY_USER_ID) Long tokenUserId,
             @NotNull @PathVariable(value = "users_id") Long userId,
             @RequestBody UserReqDto reqDto
-    ){
+    ) {
         UserInfoDto infoDto = UserInfoDto
                 .builder()
                 .id(userId)
@@ -69,6 +75,25 @@ public class UserController {
                         .data(Map.of(
                                 "updated_at", String.valueOf(updateAt)
                         ))
+                        .build(),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<ResDTO<PagedModel<EntityModel<UserInfoDto>>>> searchUsers(
+            @NotNull @RequestHeader(name = JwtUtil.JwtHeader.KEY_USER_ROLE) UserRoleEnum tokenUserRole,
+            @ModelAttribute SearchReqDto reqDto,
+            PagedResourcesAssembler<UserInfoDto> assembler
+    ) {
+        Page<UserInfoDto> page = userService.searchUser(reqDto, tokenUserRole);
+
+        log.info("Controller, User list size: {}", page.getTotalElements());
+        return new ResponseEntity<>(
+                ResDTO.<PagedModel<EntityModel<UserInfoDto>>>builder()
+                        .code(HttpStatus.OK.value())
+                        .message("사용자의 정보를 조회했습니다.")
+                        .data(assembler.toModel(page))
                         .build(),
                 HttpStatus.OK
         );

--- a/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/presentation/request/SearchReqDto.java
+++ b/com.jv-cc.flowmesh.auth/src/main/java/com/jv_cc/flowmesh/auth/presentation/request/SearchReqDto.java
@@ -1,0 +1,16 @@
+package com.jv_cc.flowmesh.auth.presentation.request;
+
+import com.jv_cc.flowmesh.auth.infrastructor.constants.PageOrderType;
+import com.jv_cc.flowmesh.auth.infrastructor.constants.PageSortType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SearchReqDto {
+    private String username;
+    private Integer page;
+    private Integer limit;
+    private PageOrderType order;
+    private PageSortType sort;
+}

--- a/com.jv-cc.flowmesh.auth/src/main/resources/application-dev.yml
+++ b/com.jv-cc.flowmesh.auth/src/main/resources/application-dev.yml
@@ -11,11 +11,13 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true
         format_sql: true
+        use_sql_comments: true
+        default_batch_fetch_size: 500
   config:
     import: classpath:application-key.yml
 

--- a/http/auth.http
+++ b/http/auth.http
@@ -42,3 +42,8 @@ X-User-Role: MASTER
   "email": "user13@email.com",
   "slack_id": "U13RFDJRQEB"
 }
+
+### 사용자 검색
+GET localhost:19045/api/users?username=user12&page=0&limit=10&sort=USERNAME&order=ASC
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJ1c2VyX2lkIjo2NTU0MjMwMDUyODE1Mzg3NzYsInVzZXJfcm9sZSI6IkNVU1RPTUVSIiwiaXNzIjoiYXV0aCIsImlhdCI6MTczNDEwMTgyNSwiZXhwIjoxNzM0MTAyNDI1fQ.sKta_xTRavvoP4xmi48Akj4-GoWnOdy2PIZJ4Og9JkpHCZGCnJ8wd4b2Eh2yltKB80MIioUqTeqD-YKNLb_8BA
+X-User-Role: MASTER


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #47

## 📝 Description

- 마스터 관리자가 username으로 사용자에 대한 정보를 검색합니다.
 
## 💬 To Reivewers

- QueryDSL은 추후에 고려하는 것으로 하고 기본 페이징 기능의 서치 기능입니다.
- 대신 일반`Page`객체가 아니라 특강때 알려주신 `PagedModel` 타입으로 반환해주기 위해서 Spring-Hateoas 디펜던시 추가하고 `PagedResourcesAssembler`객체를 사용해 변환해주었습니다.